### PR TITLE
Support hybrid properties

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -37,6 +37,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.orm.relationships import RelationshipProperty
 from sqlalchemy.ext.declarative.api import DeclarativeMeta
+from sqlalchemy.ext.hybrid import hybrid_property
 
 __version__ = 0.3
 
@@ -1914,6 +1915,9 @@ class CollectionViewBase:
             key: getattr(item, key)
             for key in self.requested_attributes.keys()
         }
+        for key, col in sqlalchemy.inspect(self.model).all_orm_descriptors.items():
+            if isinstance(col, hybrid_property):
+                atts[key] = getattr(item, key)
 
         rels = {}
         for key, rel in self.relationships.items():

--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -1860,6 +1860,9 @@ class CollectionViewBase:
         else:
             return False
 
+    def invisible_column(self, column):
+        return hasattr(column, 'info') and column.info == 'invisible'
+
     def serialise_resource_identifier(self, obj_id):
         '''Return a resource identifier dictionary for id "obj_id"
 
@@ -1915,9 +1918,12 @@ class CollectionViewBase:
             key: getattr(item, key)
             for key in self.requested_attributes.keys()
         }
+
         for key, col in sqlalchemy.inspect(self.model).all_orm_descriptors.items():
             if isinstance(col, hybrid_property):
                 atts[key] = getattr(item, key)
+            if self.invisible_column(col):
+                atts.pop(key, None)
 
         rels = {}
         for key, rel in self.relationships.items():


### PR DESCRIPTION
use ‘info’ column property, to set a column as ‘invisible’ if it should
not be returned. This would allow returning an hybrid_column, w/o
returning the original column