### PR TITLE
allow model renaming

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -36,7 +36,6 @@ from sqlalchemy.orm import load_only
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.orm.relationships import RelationshipProperty
-from sqlalchemy import or_
 from sqlalchemy.ext.declarative.api import DeclarativeMeta
 from sqlalchemy.ext.hybrid import hybrid_property
 
@@ -1826,7 +1825,7 @@ class CollectionViewBase:
             q = q.options(load_only(rel_view.key_column.name))
         if rel.direction is ONETOMANY:
             q = q.filter(obj_id == rem_col)
-        elif rel.direction is MANYTOMANY:        
+        elif rel.direction is MANYTOMANY:
             q = q.filter(
                 obj_id == rel.primaryjoin.right
             ).filter(


### PR DESCRIPTION
1. minor bug fix on exception
2. if SQLAlchemy model has property __alt_mode_name__, the value will
be used as the model name instead of the table name