### PR TITLE
one to many

### DIFF
--- a/pyramid_jsonapi/__init__.py
+++ b/pyramid_jsonapi/__init__.py
@@ -1958,7 +1958,7 @@ class CollectionViewBase:
         else:
             q = q.options(load_only(rel_view.key_column.name))
         if rel.direction is ONETOMANY:
-            q = q.filter(obj_id == rem_col)
+            q = q.filter(str(rel.primaryjoin).replace(str(local_col), str(obj_id)))
         elif rel.direction is MANYTOMANY:
             q = q.filter(
                 obj_id == rel.primaryjoin.right


### PR DESCRIPTION
There’s a bug when relationship is used w/ ‘primary join’ that
overrides the basic relationship, then related_query won’t take this
into account. The bug fix address one-to-many relationships